### PR TITLE
gui: fix missing icon for vtf files linux

### DIFF
--- a/install/_install.cmake
+++ b/install/_install.cmake
@@ -54,7 +54,7 @@ elseif(UNIX)
         install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/${PROJECT_NAME}.desktop"
                 DESTINATION "share/applications")
         install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/res/logo.png"
-                DESTINATION "share/pixmaps"
+                DESTINATION "share/icons/hicolor/512x512/apps"
                 RENAME "${PROJECT_NAME}.png")
 
         # MIME type info
@@ -64,9 +64,6 @@ elseif(UNIX)
         install(FILES "${CMAKE_CURRENT_LIST_DIR}/linux/generated/mime-type.xml"
                 DESTINATION "share/mime/packages"
                 RENAME "${PROJECT_NAME}.xml")
-        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/res/logo.png"
-                DESTINATION "share/icons/hicolor/512x512/mimetypes"
-                RENAME "image-x-vtf.png")
     endif()
 else()
     message(FATAL_ERROR "No install rules for selected platform.")

--- a/install/linux/mime-type.xml.in
+++ b/install/linux/mime-type.xml.in
@@ -2,7 +2,7 @@
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
     <mime-type type="image/x-vtf">
         <comment>Valve Texture Format File</comment>
-        <icon name="image-x-vtf"/>
+        <icon name="maretf"/>
         <acronym>VTF</acronym>
         <expanded-acronym>Valve Texture Format</expanded-acronym>
         <glob-deleteall/>


### PR DESCRIPTION
# Issue
VTF files do not show the MareTF icon on Linux as of right now. Installing maretf and looking at a bunch of VTF files, it looks like the following right now:
<img width="2722" height="1550" alt="image" src="https://github.com/user-attachments/assets/08af4769-d85a-43e7-aa9a-e92550cf52e6" />

# Solution
After some experimenting, I found out how to get the icon to show up the files:
1. The `maretf.png` icon needs to be installed ` /usr/share/icons/hicolor/512x512/apps` instead of `/usr/share/pixmaps`. As far as I understand, `/usr/share/pixmaps` is an old/legacy folder for icons, and applications should instead install to the former location listed before.
2. The icon listed in the xml mime file needs to be named `maretf`. Even whenever `maretf.png` was installed at `/usr/share/icons/hicolor/512x512/apps/maretf.png`, `image-x-vtf.png` was installed at `/usr/share/icons/hicolor/512x512/mimetypes/image-x-vtf.png`, and the mime file was left to use `image-x-vtf` for its icon, still no icons.

# Result
Using this patch and not touching any files after installation, I get:
<img width="2722" height="1550" alt="Screenshot_20250725_231129" src="https://github.com/user-attachments/assets/630a9499-4ba8-488e-9614-fdf743588124" />

## Edit
Now, I still don't know what's currently wrong with how stuff is going on rn, so maybe we should look into this more? Also, fyi, this issue affects vpkedit too.