### PR TITLE
Removed NSIS version pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Install NSIS
         uses: negrutiu/nsis-install@v3
         with:
-          version: 'v3.11.7461.309'
           arch: x64
 
       - name: Configure CMake


### PR DESCRIPTION
The original issue that lead to the NSIS version pin was (finally) resolved in [nsis/3.13.7497.330](https://github.com/negrutiu/nsis/releases/tag/v3.13.7497.330)
Thank you for [reporting the problem and providing a solution](https://github.com/negrutiu/nsis-install/pull/3)